### PR TITLE
fix: Add main publication task as a dependency

### DIFF
--- a/src/main/java/me/shedaniel/unifiedpublishing/UnifiedPublishingProject.java
+++ b/src/main/java/me/shedaniel/unifiedpublishing/UnifiedPublishingProject.java
@@ -103,6 +103,7 @@ public class UnifiedPublishingProject {
     public void mainPublication(Task task) {
         if (task instanceof AbstractArchiveTask) {
             this.mainPublication.set(task.getProject().provider(() -> ((AbstractArchiveTask) task).getArchiveFile().get()));
+            this.publicationDependencies.add(task);
         } else {
             throw new IllegalArgumentException("Task must be an AbstractArchiveTask");
         }


### PR DESCRIPTION
This fixes out of order execution of the main publication task which in my case resulted in an invalid jar file being uploaded.